### PR TITLE
fix: explicitly set GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,10 @@ env:
   DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
   OWNER: ${{ github.repository_owner }}
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.com/renovatebot/docker-renovate/pull/244
