### PR TITLE
feat: drop node versions before v14.15.0

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -1,7 +1,7 @@
 {
   "image": "node",
   "versioning": "semver",
-  "startVersion": "12.16.0",
+  "startVersion": "14.15.0",
   "extractVersion": "^v(?<version>.*)$",
   "cache": "docker-build-cache"
 }

--- a/renovate.Dockerfile
+++ b/renovate.Dockerfile
@@ -1,11 +1,13 @@
 # renovate rebuild trigger
 
-# EOL: 2022-04-30
-FROM node:12.22.12@sha256:01627afeb110b3054ba4a1405541ca095c8bfca1cb6f2be9479c767a2711879e
-
 # EOL: 2023-04-30
 FROM node:14.19.1@sha256:2f39686f6d0b2687550659367fa11f56018a0f782b7e30f1a0ea56b11dece124
 
 # EOL: 2024-04-30
 FROM node:16.15.0@sha256:a6c217d7c8f001dc6fc081d55c2dd7fb3fefe871d5aa7be9c0c16bd62bea8e0c
 
+# EOL: 2025-04-30
+FROM node:18.0.0
+
+# EOL: 2026-04-30
+#FROM node:20.0.0


### PR DESCRIPTION
will improve build tool, to easier exclude expired v15, and v17 in a alter pr